### PR TITLE
FIX curl_setopt(): CURLOPT_SSL_VERIFYHOST no longer accepts the value 1, …

### DIFF
--- a/classes/ggwebservicesclient.php
+++ b/classes/ggwebservicesclient.php
@@ -1098,7 +1098,7 @@ class ggWebservicesClient
     protected $ProxyAuthType = 1;
     protected $AcceptedCompression = '';
     protected $SSLVerifyPeer = true;
-    protected $SSLVerifyHost = 1;
+    protected $SSLVerifyHost = 2;
     protected $SSLCAInfo = '';
 
     // below here: yet to be used...


### PR DESCRIPTION
…value 2 will be used instead

When the verify value is 1, curl_easy_setopt will return an error and the option value will not be changed. It was previously (in 7.28.0 and earlier) a debug option of some sorts, but it is no longer supported due to frequently leading to programmer mistakes. Future versions will stop returning an error for 1 and just treat 1 and 2 the same.